### PR TITLE
docs(guia-de-contribuicao): adiciona políticas de commits e branches

### DIFF
--- a/docs/guia-de-contribuicao/politica-de-branches.md
+++ b/docs/guia-de-contribuicao/politica-de-branches.md
@@ -1,0 +1,58 @@
+## Objetivo
+
+Estabelecer um modelo único de ramificação (Git Flow) para todos os repositórios da organização **EHFAKE**, facilitando entregas previsíveis, releases controladas e manutenção de código em produção.
+
+## Modelo Geral
+
+| Branch       | Função                                 | Origem           | Destino        | Prefixos derivados       |
+| ------------ | -------------------------------------- | ---------------- | -------------- | ------------------------ |
+| **main**     | Código estável (produção)              | release / hotfix | —              | —                        |
+| **develop**  | Integração contínua                    | main             | release        | feature/, bugfix/        |
+| **feature/** | Novas funcionalidades                  | develop          | develop        | `feature/<issue>-<slug>` |
+| **bugfix/**  | Correções em desenvolvimento           | develop          | develop        | `bugfix/<issue>-<slug>`  |
+| **release/** | Preparação de versão                   | develop          | main & develop | `release/vX.Y.Z`         |
+| **hotfix/**  | Correções críticas em produção         | main             | main & develop | `hotfix/vX.Y.Z`          |
+| **docs/**     | Melhoria de documentação (repo *docs*) | main             | main           | `doc/<issue>-<slug>`     |
+| **gh-pages** | Site gerado pelo MkDocs                | mkdocs gh‑deploy | —              | —                        |
+
+### Convenções de nomenclatura
+
+- `<issue>`: número da issue relacionada.
+- `<slug>`: descrição curta em *kebab‑case*.
+- Versões seguem [Semantic Versioning](https://semver.org) `MAJOR.MINOR.PATCH`.
+
+## Fluxo Resumido
+
+1. **Feature**: `feature/123-melhora-busca` ← develop → PR → develop → *Squash & Merge*.
+2. **Release**: `release/v1.2.0` ← develop → PR → main & develop → tag `v1.2.0`.
+3. **Hotfix**: `hotfix/v1.2.1` ← main → PR → main & develop → tag `v1.2.1`.
+4. **Documentação**: `doc/456-guia-instalação` ← main → PR → main → `mkdocs gh-deploy` publica em **gh-pages**.
+
+## Repositórios e Particularidades
+
+| Repositório    | Branches principais | Observações                                                                                                                           |
+| -------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **docs**       | main, gh-pages      | Ciclo de utilização de branches `doc/*` para atualizações referente a documentação que posteriormente seguirá o fluxo de Commit e PR. |
+| **datasets**   | main                | Ciclo Git Flow simplificado; crie branches `feature/*`, `bugfix/*`, etc. Releases de lotes grandes via `release/*`.                   |
+| **fakebuster** | main, develop       | Implementa tratamento ML com RAGFlow. Fluxo Git Flow completo.                                                                        |
+| **backend**    | main, develop       | API e serviços. Fluxo Git Flow completo.                                                                                              |
+| **frontend**   | main, develop       | Interface web. Fluxo Git Flow completo.                                                                                               |
+
+## Regras de Merge
+
+- Todo PR necessita **1+ reviewer** e pipeline CI verde.
+- **Squash & Merge** para feature, bugfix e doc.
+- **Merge commit** preservado em release e hotfix para manter histórico explícito.
+- Tags criadas **apenas** em `main`.
+
+## Automação
+
+- GitHub Actions valida nome de branch usando regex.
+- Releases publicam artefatos correspondentes (containers, pacotes npm, modelos ML).
+
+## Histórico do documento
+
+| Versão | Data       | Descrição            | Autor         |
+| ------ | ---------- | -------------------- | ------------- |
+| 1.0    | 18/04/2025 | Criação do documento | Equipe EHFAKE |
+

--- a/docs/guia-de-contribuicao/politica-de-commits.md
+++ b/docs/guia-de-contribuicao/politica-de-commits.md
@@ -1,0 +1,66 @@
+## Objetivo
+Padronizar as mensagens de commit em todos os repositórios da organização **EHFAKE**, garantindo histórico limpo, rastreável e compatível com ferramentas de automação de changelog e versionamento semântico.
+
+## Especificação adotada
+- Baseada na especificação **Conventional Commits v1.0.0**.
+- Alinhada à convenção Angular para corpo e rodapé.
+- **chore** **não** é um tipo permitido.
+
+### Tipos permitidos
+| Tipo | Descrição | Exemplos de uso |
+|------|-----------|-----------------|
+| **build** | Mudanças que afetam o sistema de build ou dependências externas | ajustes no Dockerfile, atualização de dependências |
+| **static** | Alterações em conteúdo estático (imagens, textos, ícones) | troca de logotipo, inclusão de assets |
+| **ci** | Configuração ou ajustes de CI | atualização de workflow GitHub Actions |
+| **cd** | Configurações de entrega contínua | modificação de pipeline de deploy |
+| **docs** | Apenas mudanças na documentação | atualização do README, inclusão de tutoriais |
+| **feat** | Adição de nova funcionalidade | criação de endpoint, novo componente React |
+| **fix** | Correção de bug | ajuste de overflow, tratamento de exceção |
+| **perf** | Melhoria de performance | cache em consulta, lazy‑loading |
+| **refactor** | Refatoração sem alteração de comportamento | reorganização de módulos, renomeação de classes |
+| **improve** | Pequenas melhorias visuais ou de usabilidade | melhoria de copy, ajuste de espaçamento |
+| **style** | Mudanças de formatação e estilo de código | lint, prettier, remoção de imports |
+| **test** | Adição ou ajuste de testes | novos testes unitários, correção de mocks |
+| **revert** | Reversão de commit anterior | revert "feat(auth): add OAuth2" |
+
+## Estrutura da mensagem
+```
+<tipo>(<escopo opcional>): <título sucinto no imperativo>
+
+<corpo opcional>
+
+<rodapé opcional>
+```
+
+### Regras
+- **Título** ≤ 50 caracteres; corpo envolto a 72 caracteres por linha.
+- Use **imperativo, tempo presente** (ex.: "corrige layout", "adiciona teste").
+- Adote *kebab‑case* nos **escopos** (ex.: `backend/auth`, `frontend/ui`).
+- Inclua `BREAKING CHANGE:` no rodapé para alterações incompatíveis.
+- Relacione issues no rodapé (`Closes #123`).
+- Commits devem ser **atômicos** (uma mudança lógica por commit).
+- Prefira _squash & merge_ para unificar histórico de feature/bugfix.
+
+### Exemplos
+```
+feat(backend/auth): adiciona rotação de refresh token
+
+Implementa novo fluxo de rotação usando JWT ID, reduzindo riscos de reuse...
+
+Closes #45
+```
+```
+fix(frontend/ui): corrige alinhamento do botão de login em telas < 320px
+```
+```
+docs(datasets): atualiza README com processo de curadoria
+```
+
+## Automação
+Todos os repositórios possuem **Husky** + **commitlint** configurados para validar esta política. Pushes que não obedecerem às regras são rejeitados pelo servidor.
+
+## Histórico do documento
+| Versão | Data | Descrição | Autor |
+|--------|------|-----------|-------|
+| 1.0 | 18/04/2025 | Criação do documento | Equipe EHFAKE |
+


### PR DESCRIPTION
# Descrição
Adiciona os arquivos **`politica-de-commits.md`** e **`politica-de-branches.md`** ao diretório `docs/guia-de-contribuicao/`.  
Esses documentos formalizam:

1. A convenção **Conventional Commits v1.0.0** para todas as mensagens de commit.  
2. O modelo **Git Flow** unificado (main, develop, feature, release, hotfix, doc) para todos os repositórios da organização.

O objetivo é padronizar o processo de contribuição, facilitar a revisão de código e automatizar changelog/versionamento.

## 🗂️ Tipo de Mudança
- [x] 📝 Documentação (*docs*)

## 📌 Checklist
- [x] Seguimento do Guia de Contribuição aqui proposto para o EH-FAKE.
- [x] Documentação atualizada (MkDocs exibirá as novas páginas)  
- [x] Sem dependências pendentes

## 🔗 Issues Relacionadas
*Não se aplica*

## 🧪 Como Testar
1. Fazer checkout desta branch.  
2. Executar `mkdocs serve` no repositório **docs**.  
3. Navegar até `http://localhost:8000/guia-de-contribuicao/` e verificar se as páginas de políticas de commits e branches aparecem formatadas corretamente.

## 📷 Evidências
*Não se aplica*

## 📃 Notas Adicionais
*Não se aplica*