### PR TITLE
ci(workflow): separa build e deploy da documentação

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
   workflow_dispatch:
 
 permissions:
@@ -42,7 +39,7 @@ jobs:
         
   deploy-docs:
     needs: build-docs
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,4 +1,4 @@
-name: Deploy Documentação
+name: Documentação - Verifica e Publica
 
 on:
   push:
@@ -19,7 +19,30 @@ permissions:
   contents: write
 
 jobs:
-  deploy:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build documentation
+        run: mkdocs build --strict
+        
+  deploy-docs:
+    needs: build-docs
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# Descrição
Divide o workflow **deploy-docs.yml** em dois jobs independentes:

1. **build-docs** – roda em *push* e em *pull_request* para apenas **construir** a documentação e detectar erros de build.
2. **deploy-docs** – roda **apenas** em:
   - push direto na branch **main**
   - gatilho manual (**workflow_dispatch**)

Isso evita que a publicação em **gh‑pages** ocorra durante a revisão de um PR, garantindo que o deploy só aconteça depois do merge na *main*.

## 🗂️ Tipo de Mudança
- [x] 🐞 Correção de bug (*fix*)
- [x] 📝 Documentação (*docs*) <sup>*(afeta processo de docs)*</sup>
- [x] ⚙️ Build/CI (*ci*)

## 📌 Checklist
- [x] Mensagem de commit segue **Conventional Commits**
- [x] Nome da branch segue a **Política de Branches Git Flow** (`docs/melhoria-workflow-deploy`)
- [x] Documentação CI atualizada (comments no YAML)
- [x] Pipeline CI/CD aprovado
- [x] Sem dependências pendentes

## 🔗 Issues Relacionadas
*Não Aplicável*

## 🧪 Como Testar
1. Crie um PR a partir desta branch e verifique que **somente o job `build-docs`** é executado.
2. Após o merge na **main**, observe que o job **`deploy-docs`** é disparado e publica em **gh‑pages**.
3. (Opcional) Acione manualmente o workflow via *Actions → deploy-docs → Run workflow* para validar o gatilho `workflow_dispatch`.

## 📷 Evidências
*Logs do CI anexam-se automaticamente ao PR.*

## 📃 Notas Adicionais
*Não aplicável*
